### PR TITLE
Cloud Functions Node10 support

### DIFF
--- a/out/fire-slack.js
+++ b/out/fire-slack.js
@@ -73,9 +73,9 @@ exports.send = (options) => __awaiter(this, void 0, void 0, function* () {
     }
     webhookOptions.attachments[0].ts = webhookOptions.attachments[0].ts || new Date().getTime() / 1000;
     webhookOptions.attachments[0].fields = webhookOptions.attachments[0].fields || [];
-    if (global.process.env.FUNCTION_NAME) {
-        const functionName = global.process.env.FUNCTION_NAME;
-        let value = global.process.env.FUNCTION_NAME;
+    if (global.process.env.K_SERVICE) {
+        const functionName = global.process.env.K_SERVICE;
+        let value = global.process.env.K_SERVICE;
         if (global.process.env.FUNCTION_MEMORY_MB) {
             value += ` (${global.process.env.FUNCTION_MEMORY_MB} MB)`;
         }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
   },
   "dependencies": {
     "typed-slack": "^0.1.3"
+  },
+  "engine": {
+    "node" : ">=10.0.0"
   }
 }

--- a/src/fire-slack.ts
+++ b/src/fire-slack.ts
@@ -87,9 +87,9 @@ export const send = async (options: SendOptions) => {
   webhookOptions.attachments[0].ts = webhookOptions.attachments[0].ts || new Date().getTime() / 1000
   webhookOptions.attachments[0].fields = webhookOptions.attachments[0].fields || []
 
-  if (global.process.env.FUNCTION_NAME) {
-    const functionName = global.process.env.FUNCTION_NAME
-    let value = global.process.env.FUNCTION_NAME
+  if (global.process.env.K_SERVICE) {
+    const functionName = global.process.env.K_SERVICE
+    let value = global.process.env.K_SERVICE
     if (global.process.env.FUNCTION_MEMORY_MB) {
       value += ` (${global.process.env.FUNCTION_MEMORY_MB} MB)`
     }


### PR DESCRIPTION
Some env names are changed when we upgrade node version of Cloud Functions to v10.
I checked this document and change `FUNCTION_NAME` to `K_SERVICE`.
https://cloud.google.com/functions/docs/migrating/nodejs-runtimes

`FUNCTION_MEMORY_MB` is also unavailable but I remained it. We can use it by setting manually.